### PR TITLE
Fix body return code check in download initialization

### DIFF
--- a/src/main/java/org/kopi/ebics/xml/DownloadInitializationResponseElement.java
+++ b/src/main/java/org/kopi/ebics/xml/DownloadInitializationResponseElement.java
@@ -48,12 +48,13 @@ public class DownloadInitializationResponseElement extends InitializationRespons
   }
 
   @Override
-  protected void processBodyReturnCode() throws NoDownloadDataAvailableException {
+  protected void processBodyReturnCode() throws EbicsException {
       String bodyRetCode = response.getBody().getReturnCode().getStringValue();
       returnCode = ReturnCode.toReturnCode(bodyRetCode, "");
       if (returnCode.equals(ReturnCode.EBICS_NO_DOWNLOAD_DATA_AVAILABLE)) {
         throw new NoDownloadDataAvailableException();
       }
+      checkReturnCode(returnCode);
   }
 
   @Override


### PR DESCRIPTION
No exception is thrown if download initialization fails for any reason other than `NO_DOWNLOAD_DATA_AVAILABLE`.

The fix ensures that an `EbicsException` is thrown if the return code is not `EBICS_OK`.