### PR TITLE
Implement OrderType as interface to allow arbitrary order types

### DIFF
--- a/src/main/java/org/kopi/ebics/client/EbicsClient.java
+++ b/src/main/java/org/kopi/ebics/client/EbicsClient.java
@@ -21,7 +21,6 @@ package org.kopi.ebics.client;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -46,6 +45,7 @@ import org.kopi.ebics.exception.EbicsException;
 import org.kopi.ebics.exception.NoDownloadDataAvailableException;
 import org.kopi.ebics.interfaces.Configuration;
 import org.kopi.ebics.interfaces.EbicsBank;
+import org.kopi.ebics.interfaces.EbicsOrderType;
 import org.kopi.ebics.interfaces.EbicsUser;
 import org.kopi.ebics.interfaces.InitLetter;
 import org.kopi.ebics.interfaces.LetterManager;
@@ -380,7 +380,7 @@ public class EbicsClient {
      * Sends a file to the ebics bank server
      * @throws Exception
      */
-    public void sendFile(File file, User user, Product product, OrderType orderType) throws Exception {
+    public void sendFile(File file, User user, Product product, EbicsOrderType orderType) throws Exception {
         EbicsSession session = createSession(user, product);
         OrderAttributeType.Enum orderAttribute = OrderAttributeType.OZHNN;
 
@@ -398,11 +398,11 @@ public class EbicsClient {
         }
     }
 
-    public void sendFile(File file, OrderType orderType) throws Exception {
+    public void sendFile(File file, EbicsOrderType orderType) throws Exception {
         sendFile(file, defaultUser, defaultProduct, orderType);
     }
 
-    public void fetchFile(File file, User user, Product product, OrderType orderType,
+    public void fetchFile(File file, User user, Product product, EbicsOrderType orderType,
         boolean isTest, Date start, Date end) throws IOException, EbicsException {
         FileTransfer transferManager;
         EbicsSession session = createSession(user, product);
@@ -426,7 +426,7 @@ public class EbicsClient {
         }
     }
 
-    public void fetchFile(File file, OrderType orderType, Date start, Date end) throws IOException,
+    public void fetchFile(File file, EbicsOrderType orderType, Date start, Date end) throws IOException,
         EbicsException {
         fetchFile(file, defaultUser, defaultProduct, orderType, false, start, end);
     }
@@ -574,12 +574,12 @@ public class EbicsClient {
         return defaultUser;
     }
 
-    private static void addOption(Options options, OrderType type, String description) {
-        options.addOption(null, type.name().toLowerCase(), false, description);
+    private static void addOption(Options options, EbicsOrderType type, String description) {
+        options.addOption(null, type.getCode().toLowerCase(), false, description);
     }
 
-    private static boolean hasOption(CommandLine cmd, OrderType type) {
-        return cmd.hasOption(type.name().toLowerCase());
+    private static boolean hasOption(CommandLine cmd, EbicsOrderType type) {
+        return cmd.hasOption(type.getCode().toLowerCase());
     }
 
     public static void main(String[] args) throws Exception {
@@ -642,11 +642,11 @@ public class EbicsClient {
         String outputFileValue = cmd.getOptionValue("o");
         String inputFileValue = cmd.getOptionValue("i");
 
-        List<OrderType> fetchFileOrders = Arrays.asList(OrderType.STA, OrderType.VMK,
+        List<? extends EbicsOrderType> fetchFileOrders = Arrays.asList(OrderType.STA, OrderType.VMK,
             OrderType.C52, OrderType.C53, OrderType.C54,
             OrderType.ZDF, OrderType.ZB6, OrderType.PTK, OrderType.HAC, OrderType.Z01);
 
-        for (OrderType type : fetchFileOrders) {
+        for (EbicsOrderType type : fetchFileOrders) {
             if (hasOption(cmd, type)) {
                 client.fetchFile(getOutputFile(outputFileValue), client.defaultUser,
                     client.defaultProduct, type, false, null, null);
@@ -654,9 +654,9 @@ public class EbicsClient {
             }
         }
 
-        List<OrderType> sendFileOrders = Arrays.asList(OrderType.XKD, OrderType.FUL, OrderType.XCT,
+        List<? extends EbicsOrderType> sendFileOrders = Arrays.asList(OrderType.XKD, OrderType.FUL, OrderType.XCT,
             OrderType.XE2, OrderType.CCT);
-        for (OrderType type : sendFileOrders) {
+        for (EbicsOrderType type : sendFileOrders) {
             if (hasOption(cmd, type)) {
                 client.sendFile(new File(inputFileValue), client.defaultUser,
                     client.defaultProduct, type);

--- a/src/main/java/org/kopi/ebics/client/FileTransfer.java
+++ b/src/main/java/org/kopi/ebics/client/FileTransfer.java
@@ -26,12 +26,12 @@ import java.util.Date;
 
 import org.kopi.ebics.exception.EbicsException;
 import org.kopi.ebics.interfaces.ContentFactory;
+import org.kopi.ebics.interfaces.EbicsOrderType;
 import org.kopi.ebics.io.ByteArrayContentFactory;
 import org.kopi.ebics.io.Joiner;
 import org.kopi.ebics.messages.Messages;
 import org.kopi.ebics.schema.h003.OrderAttributeType;
 import org.kopi.ebics.session.EbicsSession;
-import org.kopi.ebics.session.OrderType;
 import org.kopi.ebics.utils.Constants;
 import org.kopi.ebics.utils.Utils;
 import org.kopi.ebics.xml.DefaultEbicsRootElement;
@@ -94,7 +94,7 @@ public class FileTransfer {
    * @throws IOException
    * @throws EbicsException
    */
-  public void sendFile(byte[] content, OrderType orderType, OrderAttributeType.Enum orderAttribute)
+  public void sendFile(byte[] content, EbicsOrderType orderType, OrderAttributeType.Enum orderAttribute)
     throws IOException, EbicsException
   {
     HttpRequestSender sender = new HttpRequestSender(session);
@@ -137,7 +137,7 @@ public class FileTransfer {
                        int segmentNumber,
                        boolean lastSegment,
                        byte[] transactionId,
-                       OrderType orderType)
+                       EbicsOrderType orderType)
     throws IOException, EbicsException
   {
     UploadTransferRequestElement		uploader;
@@ -178,7 +178,7 @@ public class FileTransfer {
    * @throws IOException communication error
    * @throws EbicsException server generated error
    */
-  public void fetchFile(OrderType orderType,
+  public void fetchFile(EbicsOrderType orderType,
                         Date start,
                         Date end,
                         File outputFile)
@@ -254,7 +254,7 @@ public class FileTransfer {
    * @throws IOException communication error
    * @throws EbicsException server generated error
    */
-  public void fetchFile(OrderType orderType,
+  public void fetchFile(EbicsOrderType orderType,
                         int segmentNumber,
                         boolean lastSegment,
                         byte[] transactionId,

--- a/src/main/java/org/kopi/ebics/interfaces/EbicsOrderType.java
+++ b/src/main/java/org/kopi/ebics/interfaces/EbicsOrderType.java
@@ -1,0 +1,7 @@
+package org.kopi.ebics.interfaces;
+
+public interface EbicsOrderType {
+
+    String getCode();
+
+}

--- a/src/main/java/org/kopi/ebics/session/OrderType.java
+++ b/src/main/java/org/kopi/ebics/session/OrderType.java
@@ -19,13 +19,15 @@
 
 package org.kopi.ebics.session;
 
+import org.kopi.ebics.interfaces.EbicsOrderType;
+
 /**
  * A BCS order type.
  *
  * @author Pierre Ducroquet
  *
  */
-public enum OrderType {
+public enum OrderType implements EbicsOrderType {
     HIA,
     HAA,
     HKD,
@@ -59,5 +61,11 @@ public enum OrderType {
     XCT,
     C52,
     C53,
-    C54
+    C54;
+
+    @Override
+    public String getCode() {
+        return name();
+    }
+
 }

--- a/src/main/java/org/kopi/ebics/xml/DefaultEbicsRootElement.java
+++ b/src/main/java/org/kopi/ebics/xml/DefaultEbicsRootElement.java
@@ -44,10 +44,9 @@ import org.jdom2.input.SAXBuilder;
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.kopi.ebics.exception.EbicsException;
+import org.kopi.ebics.interfaces.EbicsOrderType;
 import org.kopi.ebics.interfaces.EbicsRootElement;
 import org.kopi.ebics.session.EbicsSession;
-import org.kopi.ebics.session.OrderType;
-
 
 public abstract class DefaultEbicsRootElement implements EbicsRootElement {
 
@@ -134,7 +133,7 @@ public abstract class DefaultEbicsRootElement implements EbicsRootElement {
    * @param type the order type.
    * @return the generated file name.
    */
-  public static String generateName(OrderType type) {
+  public static String generateName(EbicsOrderType type) {
     return type.toString() + new BigInteger(130, new SecureRandom()).toString(32);
   }
   

--- a/src/main/java/org/kopi/ebics/xml/DownloadInitializationRequestElement.java
+++ b/src/main/java/org/kopi/ebics/xml/DownloadInitializationRequestElement.java
@@ -23,6 +23,7 @@ import java.util.Calendar;
 import java.util.Date;
 
 import org.kopi.ebics.exception.EbicsException;
+import org.kopi.ebics.interfaces.EbicsOrderType;
 import org.kopi.ebics.schema.h003.EbicsRequestDocument.EbicsRequest;
 import org.kopi.ebics.schema.h003.EbicsRequestDocument.EbicsRequest.Body;
 import org.kopi.ebics.schema.h003.EbicsRequestDocument.EbicsRequest.Header;
@@ -62,7 +63,7 @@ public class DownloadInitializationRequestElement extends InitializationRequestE
    * @throws EbicsException
    */
   public DownloadInitializationRequestElement(EbicsSession session,
-                                       org.kopi.ebics.session.OrderType type,
+                                       EbicsOrderType type,
                                        Date startRange,
                                        Date endRange)
     throws EbicsException
@@ -95,7 +96,7 @@ public class DownloadInitializationRequestElement extends InitializationRequestE
 	                                          "http://www.w3.org/2001/04/xmlenc#sha256",
 	                                          decodeHex(session.getUser().getPartner().getBank().getE002Digest()));
     bankPubKeyDigests = EbicsXmlFactory.createBankPubKeyDigests(authentication, encryption);
-    orderType = EbicsXmlFactory.createOrderType(type.toString());
+    orderType = EbicsXmlFactory.createOrderType(type.getCode());
     if (type.equals(org.kopi.ebics.session.OrderType.FDL)) {
       FDLOrderParamsType		fDLOrderParamsType;
       FileFormatType 			fileFormat;

--- a/src/main/java/org/kopi/ebics/xml/DownloadInitializationResponseElement.java
+++ b/src/main/java/org/kopi/ebics/xml/DownloadInitializationResponseElement.java
@@ -23,7 +23,7 @@ import org.kopi.ebics.exception.EbicsException;
 import org.kopi.ebics.exception.NoDownloadDataAvailableException;
 import org.kopi.ebics.exception.ReturnCode;
 import org.kopi.ebics.interfaces.ContentFactory;
-import org.kopi.ebics.session.OrderType;
+import org.kopi.ebics.interfaces.EbicsOrderType;
 
 /**
  * The <code>DInitializationResponseElement</code> is the response element
@@ -41,7 +41,7 @@ public class DownloadInitializationResponseElement extends InitializationRespons
    * @param name the element name
    */
   public DownloadInitializationResponseElement(ContentFactory factory,
-                                        OrderType orderType,
+                                        EbicsOrderType orderType,
                                         String name)
   {
     super(factory, orderType, name);

--- a/src/main/java/org/kopi/ebics/xml/DownloadTransferRequestElement.java
+++ b/src/main/java/org/kopi/ebics/xml/DownloadTransferRequestElement.java
@@ -20,6 +20,7 @@
 package org.kopi.ebics.xml;
 
 import org.kopi.ebics.exception.EbicsException;
+import org.kopi.ebics.interfaces.EbicsOrderType;
 import org.kopi.ebics.schema.h003.MutableHeaderType;
 import org.kopi.ebics.schema.h003.StaticHeaderType;
 import org.kopi.ebics.schema.h003.EbicsRequestDocument.EbicsRequest;
@@ -27,7 +28,6 @@ import org.kopi.ebics.schema.h003.EbicsRequestDocument.EbicsRequest.Body;
 import org.kopi.ebics.schema.h003.EbicsRequestDocument.EbicsRequest.Header;
 import org.kopi.ebics.schema.h003.MutableHeaderType.SegmentNumber;
 import org.kopi.ebics.session.EbicsSession;
-import org.kopi.ebics.session.OrderType;
 
 /**
  * The <code>DTransferRequestElement</code> is the common elements
@@ -47,7 +47,7 @@ public class DownloadTransferRequestElement extends TransferRequestElement {
    * @param transactionId the transaction ID
    */
   public DownloadTransferRequestElement(EbicsSession session,
-                                 OrderType type,
+                                 EbicsOrderType type,
                                  int segmentNumber,
                                  boolean lastSegment,
                                  byte[] transactionId)

--- a/src/main/java/org/kopi/ebics/xml/DownloadTransferResponseElement.java
+++ b/src/main/java/org/kopi/ebics/xml/DownloadTransferResponseElement.java
@@ -21,7 +21,7 @@ package org.kopi.ebics.xml;
 
 import org.kopi.ebics.exception.EbicsException;
 import org.kopi.ebics.interfaces.ContentFactory;
-import org.kopi.ebics.session.OrderType;
+import org.kopi.ebics.interfaces.EbicsOrderType;
 
 /**
  * The <code>DTransferResponseElement</code> is the response element
@@ -39,7 +39,7 @@ public class DownloadTransferResponseElement extends TransferResponseElement {
    * @param name the element name.
    */
   public DownloadTransferResponseElement(ContentFactory factory,
-                                  OrderType orderType,
+                                  EbicsOrderType orderType,
                                   String name)
   {
     super(factory, name);

--- a/src/main/java/org/kopi/ebics/xml/InitializationRequestElement.java
+++ b/src/main/java/org/kopi/ebics/xml/InitializationRequestElement.java
@@ -29,9 +29,9 @@ import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.kopi.ebics.exception.EbicsException;
+import org.kopi.ebics.interfaces.EbicsOrderType;
 import org.kopi.ebics.schema.h003.EbicsRequestDocument;
 import org.kopi.ebics.session.EbicsSession;
-import org.kopi.ebics.session.OrderType;
 import org.kopi.ebics.utils.Utils;
 
 
@@ -53,7 +53,7 @@ public abstract class InitializationRequestElement extends DefaultEbicsRootEleme
    * @throws EbicsException
    */
   public InitializationRequestElement(EbicsSession session,
-                                      OrderType type,
+                                      EbicsOrderType type,
                                       String name)
     throws EbicsException
   {
@@ -108,7 +108,7 @@ public abstract class InitializationRequestElement extends DefaultEbicsRootEleme
    * @return the element type.
    */
   public String getType() {
-    return type.toString();
+    return type.getCode();
   }
 
   /**
@@ -158,7 +158,7 @@ public abstract class InitializationRequestElement extends DefaultEbicsRootEleme
   // --------------------------------------------------------------------
 
   private String			name;
-  protected OrderType			type;
+  protected EbicsOrderType type;
   protected byte[]			nonce;
   private static final long 		serialVersionUID = 8983807819242699280L;
 }

--- a/src/main/java/org/kopi/ebics/xml/InitializationResponseElement.java
+++ b/src/main/java/org/kopi/ebics/xml/InitializationResponseElement.java
@@ -22,9 +22,9 @@ package org.kopi.ebics.xml;
 import org.kopi.ebics.exception.EbicsException;
 import org.kopi.ebics.exception.ReturnCode;
 import org.kopi.ebics.interfaces.ContentFactory;
+import org.kopi.ebics.interfaces.EbicsOrderType;
 import org.kopi.ebics.schema.h003.EbicsResponseDocument;
 import org.kopi.ebics.schema.h003.EbicsResponseDocument.EbicsResponse;
-import org.kopi.ebics.session.OrderType;
 
 /**
  * The <code>InitializationResponseElement</code> is the common
@@ -42,7 +42,7 @@ public class InitializationResponseElement extends DefaultResponseElement {
    * @param name the element name
    */
   public InitializationResponseElement(ContentFactory factory,
-                                       OrderType orderType,
+                                       EbicsOrderType orderType,
                                        String name)
   {
     super(factory, name);
@@ -81,7 +81,7 @@ public class InitializationResponseElement extends DefaultResponseElement {
    * @return the order type.
    */
   public String getOrderType() {
-    return orderType.toString();
+    return orderType.getCode();
   }
 
   // --------------------------------------------------------------------
@@ -89,7 +89,7 @@ public class InitializationResponseElement extends DefaultResponseElement {
   // --------------------------------------------------------------------
 
   protected EbicsResponse			response;
-  private OrderType				orderType;
+  private EbicsOrderType orderType;
   private byte[]				transactionId;
   private static final long 			serialVersionUID = 7684048385353175772L;
 }

--- a/src/main/java/org/kopi/ebics/xml/NoPubKeyDigestsRequestElement.java
+++ b/src/main/java/org/kopi/ebics/xml/NoPubKeyDigestsRequestElement.java
@@ -99,7 +99,7 @@ public class NoPubKeyDigestsRequestElement extends DefaultEbicsRootElement {
     OrderDetailsType 				orderDetails;
 
     product = EbicsXmlFactory.creatProductElementType(session.getProduct().getLanguage(), session.getProduct().getName());
-    orderDetails = EbicsXmlFactory.createOrderDetailsType("DZHNN", null, OrderType.HPB.toString());
+    orderDetails = EbicsXmlFactory.createOrderDetailsType("DZHNN", null, OrderType.HPB.getCode());
     xstatic = EbicsXmlFactory.createNoPubKeyDigestsRequestStaticHeaderType(session.getBankID(),
 	                                                                   Utils.generateNonce(),
 	                                                                   Calendar.getInstance(),

--- a/src/main/java/org/kopi/ebics/xml/SPRRequestElement.java
+++ b/src/main/java/org/kopi/ebics/xml/SPRRequestElement.java
@@ -99,7 +99,7 @@ public class SPRRequestElement extends InitializationRequestElement {
 	                                          "http://www.w3.org/2001/04/xmlenc#sha256",
 	                                          decodeHex(session.getUser().getPartner().getBank().getE002Digest()));
     bankPubKeyDigests = EbicsXmlFactory.createBankPubKeyDigests(authentication, encryption);
-    orderType = EbicsXmlFactory.createOrderType(type.toString());
+    orderType = EbicsXmlFactory.createOrderType(type.getCode());
     standardOrderParamsType = EbicsXmlFactory.createStandardOrderParamsType();
     orderDetails = EbicsXmlFactory.createStaticHeaderOrderDetailsType(session.getUser().getPartner().nextOrderId(),
 	                                                              OrderAttributeType.UZHNN,

--- a/src/main/java/org/kopi/ebics/xml/TransferRequestElement.java
+++ b/src/main/java/org/kopi/ebics/xml/TransferRequestElement.java
@@ -24,9 +24,9 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 
 import org.kopi.ebics.exception.EbicsException;
+import org.kopi.ebics.interfaces.EbicsOrderType;
 import org.kopi.ebics.schema.h003.EbicsRequestDocument;
 import org.kopi.ebics.session.EbicsSession;
-import org.kopi.ebics.session.OrderType;
 import org.kopi.ebics.utils.Utils;
 
 
@@ -50,7 +50,7 @@ public abstract class TransferRequestElement extends DefaultEbicsRootElement {
    */
   public TransferRequestElement(EbicsSession session,
                                 String name,
-                                OrderType type,
+                                EbicsOrderType type,
                                 int segmentNumber,
                                 boolean lastSegment,
                                 byte[] transactionId)
@@ -101,7 +101,7 @@ public abstract class TransferRequestElement extends DefaultEbicsRootElement {
    * @return the order type element.
    */
   public String getOrderType() {
-    return type.toString();
+    return type.getCode();
   }
 
   @Override
@@ -124,7 +124,7 @@ public abstract class TransferRequestElement extends DefaultEbicsRootElement {
   protected int				segmentNumber;
   protected boolean			lastSegment;
   protected byte[]			transactionId;
-  private OrderType			type;
+  private EbicsOrderType type;
   private String 			name;
   private static final long 		serialVersionUID = -4212072825371398259L;
 }

--- a/src/main/java/org/kopi/ebics/xml/UnsecuredRequestElement.java
+++ b/src/main/java/org/kopi/ebics/xml/UnsecuredRequestElement.java
@@ -20,6 +20,7 @@
 package org.kopi.ebics.xml;
 
 import org.kopi.ebics.exception.EbicsException;
+import org.kopi.ebics.interfaces.EbicsOrderType;
 import org.kopi.ebics.schema.h003.EmptyMutableHeaderType;
 import org.kopi.ebics.schema.h003.OrderDetailsType;
 import org.kopi.ebics.schema.h003.ProductElementType;
@@ -30,7 +31,6 @@ import org.kopi.ebics.schema.h003.EbicsUnsecuredRequestDocument.EbicsUnsecuredRe
 import org.kopi.ebics.schema.h003.EbicsUnsecuredRequestDocument.EbicsUnsecuredRequest.Body.DataTransfer;
 import org.kopi.ebics.schema.h003.EbicsUnsecuredRequestDocument.EbicsUnsecuredRequest.Body.DataTransfer.OrderData;
 import org.kopi.ebics.session.EbicsSession;
-import org.kopi.ebics.session.OrderType;
 
 /**
  * The <code>UnsecuredRequestElement</code> is the common element
@@ -48,7 +48,7 @@ public class UnsecuredRequestElement extends DefaultEbicsRootElement {
    * @param orderId the order id, if null a random one is generated.
    */
   public UnsecuredRequestElement(EbicsSession session,
-                                 OrderType orderType,
+                                 EbicsOrderType orderType,
                                  String orderId,
                                  byte[] orderData)
   {
@@ -72,7 +72,7 @@ public class UnsecuredRequestElement extends DefaultEbicsRootElement {
 
     orderDetails = EbicsXmlFactory.createOrderDetailsType("DZNNN",
 						          orderId == null ? session.getUser().getPartner().nextOrderId() : orderId,
-	                                                  orderType.toString());
+	                                                  orderType.getCode());
 
     productType = EbicsXmlFactory.creatProductElementType(session.getProduct().getLanguage(),
 	                                                  session.getProduct().getName());
@@ -109,7 +109,7 @@ public class UnsecuredRequestElement extends DefaultEbicsRootElement {
   // DATA MEMBERS
   // --------------------------------------------------------------------
 
-  private OrderType			orderType;
+  private EbicsOrderType orderType;
   private String			orderId;
   private byte[]			orderData;
   private static final long 		serialVersionUID = -3548730114599886711L;

--- a/src/main/java/org/kopi/ebics/xml/UploadInitializationRequestElement.java
+++ b/src/main/java/org/kopi/ebics/xml/UploadInitializationRequestElement.java
@@ -27,6 +27,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 import org.kopi.ebics.exception.EbicsException;
 import org.kopi.ebics.interfaces.ContentFactory;
+import org.kopi.ebics.interfaces.EbicsOrderType;
 import org.kopi.ebics.io.Splitter;
 import org.kopi.ebics.schema.h003.DataEncryptionInfoType.EncryptionPubKeyDigest;
 import org.kopi.ebics.schema.h003.DataTransferRequestType;
@@ -71,7 +72,7 @@ public class UploadInitializationRequestElement extends InitializationRequestEle
    * @throws EbicsException
    */
   public UploadInitializationRequestElement(EbicsSession session,
-                                       org.kopi.ebics.session.OrderType orderType, OrderAttributeType.Enum orderAttribute,
+                                       EbicsOrderType orderType, OrderAttributeType.Enum orderAttribute,
                                        byte[] userData)
     throws EbicsException
   {
@@ -118,7 +119,7 @@ public class UploadInitializationRequestElement extends InitializationRequestEle
 	                                          "http://www.w3.org/2001/04/xmlenc#sha256",
 	                                          decodeHex(session.getUser().getPartner().getBank().getE002Digest()));
     bankPubKeyDigests = EbicsXmlFactory.createBankPubKeyDigests(authentication, encryption);
-    orderType = EbicsXmlFactory.createOrderType(type.toString());
+    orderType = EbicsXmlFactory.createOrderType(type.getCode());
     fileFormat = EbicsXmlFactory.createFileFormatType(session.getConfiguration().getLocale().getCountry().toUpperCase(),
 	                                              session.getSessionParam("FORMAT"));
 

--- a/src/main/java/org/kopi/ebics/xml/UploadTransferRequestElement.java
+++ b/src/main/java/org/kopi/ebics/xml/UploadTransferRequestElement.java
@@ -21,6 +21,7 @@ package org.kopi.ebics.xml;
 
 import org.kopi.ebics.exception.EbicsException;
 import org.kopi.ebics.interfaces.ContentFactory;
+import org.kopi.ebics.interfaces.EbicsOrderType;
 import org.kopi.ebics.io.IOUtils;
 import org.kopi.ebics.schema.h003.DataTransferRequestType;
 import org.kopi.ebics.schema.h003.DataTransferRequestType.OrderData;
@@ -31,7 +32,6 @@ import org.kopi.ebics.schema.h003.MutableHeaderType;
 import org.kopi.ebics.schema.h003.MutableHeaderType.SegmentNumber;
 import org.kopi.ebics.schema.h003.StaticHeaderType;
 import org.kopi.ebics.session.EbicsSession;
-import org.kopi.ebics.session.OrderType;
 
 /**
  * The <code>UTransferRequestElement</code> is the root element
@@ -52,7 +52,7 @@ public class UploadTransferRequestElement extends TransferRequestElement {
    * @param content the content factory
    */
   public UploadTransferRequestElement(EbicsSession session,
-                                 OrderType orderType,
+                                 EbicsOrderType orderType,
                                  int segmentNumber,
                                  boolean lastSegment,
                                  byte[] transactionId,


### PR DESCRIPTION
The `OrderType` is actually not a fixed set but has bank specific codes as well. e.g. Credit Suisse in Switzerland has `XTD` for their test environment. There even seems to be some standardisation around Switzerland specific codes: https://www.six-group.com/dam/download/banking-services/interbank-clearing/en/standardization/ebics/ebics.pdf.

I suggest opening up the 'OrderType' to be able to set any order code in the future. This change should be completely backwards compatible.