### PR TITLE
Fix Javadoc "errors"

### DIFF
--- a/src/main/java/org/kopi/ebics/certificate/CertificateManager.java
+++ b/src/main/java/org/kopi/ebics/certificate/CertificateManager.java
@@ -97,7 +97,7 @@ public class CertificateManager {
 
   /**
    * Creates the authentication certificate.
-   * @param the expiration date of a the certificate.
+   * @param end the expiration date of a the certificate.
    * @throws GeneralSecurityException
    * @throws IOException
    */

--- a/src/main/java/org/kopi/ebics/client/EbicsClient.java
+++ b/src/main/java/org/kopi/ebics/client/EbicsClient.java
@@ -180,7 +180,7 @@ public class EbicsClient {
      * @param passwordCallback
      *            a callback-handler that supplies us with the password. This
      *            parameter can be null, in this case no password is used.
-     * @return
+     * @return Ebics <code>User</code>
      * @throws Exception
      */
     public User createUser(URL url, String bankName, String hostId, String partnerId,

--- a/src/main/java/org/kopi/ebics/client/TransferState.java
+++ b/src/main/java/org/kopi/ebics/client/TransferState.java
@@ -79,7 +79,7 @@ public class TransferState implements Serializable {
   }
 
   /**
-   * @param transactionID the transactionID to set
+   * @param transactionId the transactionID to set
    */
   public void setTransactionId(byte[] transactionId) {
     this.transactionId = transactionId;

--- a/src/main/java/org/kopi/ebics/client/User.java
+++ b/src/main/java/org/kopi/ebics/client/User.java
@@ -32,7 +32,6 @@ import java.security.interfaces.RSAPublicKey;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.crypto.dsig.SignedInfo;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.kopi.ebics.certificate.CertificateManager;
@@ -42,6 +41,7 @@ import org.kopi.ebics.interfaces.EbicsUser;
 import org.kopi.ebics.interfaces.PasswordCallback;
 import org.kopi.ebics.interfaces.Savable;
 import org.kopi.ebics.utils.Utils;
+import org.kopi.ebics.xml.SignedInfo;
 import org.kopi.ebics.xml.UserSignature;
 
 /**
@@ -283,7 +283,7 @@ public class User implements EbicsUser, Savable {
    * @param email the user email
    * @param country the user country
    * @param organization the user organization
-   * @return
+   * @return Distinguished Names
    */
   private String makeDN(String name,
                         String email,

--- a/src/main/java/org/kopi/ebics/interfaces/Configuration.java
+++ b/src/main/java/org/kopi/ebics/interfaces/Configuration.java
@@ -65,7 +65,7 @@ public interface Configuration {
   /**
    * Returns the directory path of the key store that contains
    * bank and user certificates.
-   * @param the ebics user.
+   * @param user the ebics user.
    * @return the key store directory of a given user.
    */
   public String getKeystoreDirectory(EbicsUser user);
@@ -80,7 +80,6 @@ public interface Configuration {
 
   /**
    * Returns the object serialization directory.
-   * @param user the ebics user
    * @return the object serialization directory.
    */
   public String getSerializationDirectory();

--- a/src/main/java/org/kopi/ebics/interfaces/EbicsUser.java
+++ b/src/main/java/org/kopi/ebics/interfaces/EbicsUser.java
@@ -83,13 +83,13 @@ public interface EbicsUser {
 
   /**
    * Sets the authentication certificate.
-   * @param a005certificate the authentication certificate.
+   * @param x002certificate the authentication certificate.
    */
   public void setX002Certificate(X509Certificate x002certificate);
 
   /**
    * Sets the encryption certificate.
-   * @param a005certificate the encryption certificate.
+   * @param e002certificate the encryption certificate.
    */
   public void setE002Certificate(X509Certificate e002certificate);
 
@@ -101,13 +101,13 @@ public interface EbicsUser {
 
   /**
    * Sets the authentication private key
-   * @param a005Key the authentication private key
+   * @param x002Key the authentication private key
    */
   public void setX002PrivateKey(PrivateKey x002Key);
 
   /**
    * Sets the encryption private key
-   * @param a005Key the encryption private key
+   * @param e002Key the encryption private key
    */
   public void setE002PrivateKey(PrivateKey e002Key);
 

--- a/src/main/java/org/kopi/ebics/io/IOUtils.java
+++ b/src/main/java/org/kopi/ebics/io/IOUtils.java
@@ -132,7 +132,7 @@ public class IOUtils {
   /**
    * Returns the content of a <code>ContentFactory</code> as a byte array
    * @param content
-   * @return
+   * @return content of a <code>ContentFactory</code> as a <code>byte[]</code>
    * @throws EbicsException
    */
     public static byte[] getFactoryContent(ContentFactory content) throws EbicsException {

--- a/src/main/java/org/kopi/ebics/io/Splitter.java
+++ b/src/main/java/org/kopi/ebics/io/Splitter.java
@@ -113,7 +113,7 @@ public class Splitter {
    * a given segment number.
    * 
    * @param segmentNumber the segment number
-   * @return
+   * @return content of a data segment
    */
   public ContentFactory getContent(int segmentNumber) {
     byte[]		segment;

--- a/src/main/java/org/kopi/ebics/letter/AbstractInitLetter.java
+++ b/src/main/java/org/kopi/ebics/letter/AbstractInitLetter.java
@@ -370,7 +370,7 @@ public abstract class AbstractInitLetter implements InitLetter {
 
     /**
      * Returns the letter content
-     * @return
+     * @return letter content as a <code>byte[]</code>
      */
     public byte[] getLetter() {
       return out.toByteArray();

--- a/src/main/java/org/kopi/ebics/utils/Utils.java
+++ b/src/main/java/org/kopi/ebics/utils/Utils.java
@@ -72,7 +72,7 @@ public final class Utils {
    * 
    * @param toZip the input to be compressed
    * @return the compressed input data
-   * @throws IOException compression failed
+   * @throws EbicsException compression failed
    */
   public static byte[] zip(byte[] toZip) throws EbicsException {
 

--- a/src/main/java/org/kopi/ebics/xml/EbicsXmlFactory.java
+++ b/src/main/java/org/kopi/ebics/xml/EbicsXmlFactory.java
@@ -294,7 +294,7 @@ public class EbicsXmlFactory {
   /**
    * Creates a new <code>SignaturePubKeyOrderDataDocument</code> XML object
    * @param signaturePubKeyOrderData the <code>SignaturePubKeyOrderDataType</code> element
-   * @return
+   * @return the <code>SignaturePubKeyOrderDataDocument</code> XML object
    */
   public static SignaturePubKeyOrderDataDocument createSignaturePubKeyOrderDataDocument(SignaturePubKeyOrderDataType signaturePubKeyOrderData) {
     SignaturePubKeyOrderDataDocument newSignaturePubKeyOrderDataDocument = SignaturePubKeyOrderDataDocument.Factory.newInstance();
@@ -689,7 +689,7 @@ public class EbicsXmlFactory {
    * @param product the <code>ProductElementType</code> element
    * @param orderDetails the <code>OrderDetailsType</code> element
    * @param securityMedium the user security medium
-   * @return
+   * @return <code>NoPubKeyDigestsRequestStaticHeaderType</code>
    */
   public static NoPubKeyDigestsRequestStaticHeaderType createNoPubKeyDigestsRequestStaticHeaderType(String hostId,
                                                                                                     byte[] nonce,
@@ -864,7 +864,6 @@ public class EbicsXmlFactory {
    * Creates a new <code>StaticHeaderType</code> XML object
    * @param hostId the host ID
    * @param nonce the random nonce
-   * @param numSegments the segments number
    * @param partnerId the partner ID
    * @param product the <code>Product</code> element
    * @param securityMedium the security medium
@@ -989,7 +988,6 @@ public class EbicsXmlFactory {
 
   /**
    * Creates a new <code>StandardOrderParamsType</code> XML object
-   * @param fileFormat the <code>FileFormatType</code> element
    * @return the <code>StandardOrderParamsType</code> XML object
    */
   public static StandardOrderParamsType createStandardOrderParamsType() {

--- a/src/main/java/org/kopi/ebics/xml/SignedInfo.java
+++ b/src/main/java/org/kopi/ebics/xml/SignedInfo.java
@@ -101,7 +101,6 @@ public class SignedInfo extends DefaultEbicsRootElement {
   /**
    * Returns the signed info element as an <code>XmlObject</code>
    * @return he signed info element
-   * @throws EbicsException user Signature and Canonicalization errors
    */
   public SignatureType getSignatureType() {
     return ((SignatureType)document);

--- a/src/main/java/org/kopi/ebics/xml/TransferRequestElement.java
+++ b/src/main/java/org/kopi/ebics/xml/TransferRequestElement.java
@@ -46,7 +46,7 @@ public abstract class TransferRequestElement extends DefaultEbicsRootElement {
    * @param type the order type
    * @param segmentNumber the segment number to be sent
    * @param lastSegment is it the last segment?
-   * @param transactionID the transaction ID
+   * @param transactionId the transaction ID
    */
   public TransferRequestElement(EbicsSession session,
                                 String name,

--- a/src/main/java/org/kopi/ebics/xml/TransferResponseElement.java
+++ b/src/main/java/org/kopi/ebics/xml/TransferResponseElement.java
@@ -37,7 +37,6 @@ public class TransferResponseElement extends DefaultResponseElement {
   /**
    * Constructs a new <code>TransferResponseElement</code> element.
    * @param factory the content factory
-   * @param orderType the order type
    * @param name the element name;
    */
   public TransferResponseElement(ContentFactory factory, String name) {


### PR DESCRIPTION
My eclipse environment is set up with stricter rules regarding javadoc.
I thought it would be a not too controversial change proposal as it only touches JavaDoc.
One import was changed, but only as it was a javadoc reference.

Missing return declarations
Throws in contradiction with method signature
Typos in params names